### PR TITLE
Fix windows colcon build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,5 +31,5 @@ install (TARGETS backward DESTINATION ${LIB_INSTALL_DIR})
 # Two steps to create `ign`, First using `configure_file`, to interpolate cmake variables. Then
 # use `file(GENERATE ...)` to use generator expressions
 configure_file(ign.in ${PROJECT_BINARY_DIR}/${executable_name}_before_gen)
-file(GENERATE OUTPUT ${PROJECT_BINARY_DIR}/${executable_name} INPUT ${PROJECT_BINARY_DIR}/${executable_name}_before_gen )
-install (PROGRAMS ${PROJECT_BINARY_DIR}/${executable_name} DESTINATION ${BIN_INSTALL_DIR})
+file(GENERATE OUTPUT ${PROJECT_BINARY_DIR}/$<CONFIG>/${executable_name} INPUT ${PROJECT_BINARY_DIR}/${executable_name}_before_gen )
+install (PROGRAMS ${PROJECT_BINARY_DIR}/$<CONFIG>/${executable_name} DESTINATION ${BIN_INSTALL_DIR})


### PR DESCRIPTION
# 🦟 Bug fix

Fixes colcon builds on Windows

## Summary

Some windows builds that use `ign-tools` have been failing since https://github.com/ignitionrobotics/ign-tools/pull/63 was merged:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_sensors-ci-win&build=117)](https://build.osrfoundation.org/job/ign_sensors-ci-win/117/) https://build.osrfoundation.org/job/ign_sensors-ci-win/117/

The solution is to generate to a unique folder based on `$<CONFIG>`

Testing with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_sensors-ci-win&build=120)](https://build.osrfoundation.org/job/ign_sensors-ci-win/120/) https://build.osrfoundation.org/job/ign_sensors-ci-win/1120/

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
