### PR TITLE
Add flag to get standard-compliant exception handling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,14 @@ if(WIN32)
   set(executable_name "ign.rb")
 endif()
 
+if(MSVC)
+
+  # We always want this flag to be specified so we get standard-compliant
+  # exception handling.
+  # EHsc: Use standard-compliant exception handling
+  add_compile_options("/EHsc")
+endif()
+
 cmake_policy(PUSH)
 cmake_policy(SET CMP0042 NEW)
 add_library(backward SHARED backward.cc)
@@ -25,11 +33,6 @@ if(MSVC)
   # Suppress warning from vendored package
   target_compile_options(backward PUBLIC /wd4267)
   target_compile_options(backward PUBLIC /wd4996)
-
-  # We always want this flag to be specified so we get standard-compliant
-  # exception handling.
-  # EHsc: Use standard-compliant exception handling
-  add_compile_options("/EHsc")
 endif()
 install (TARGETS backward DESTINATION ${LIB_INSTALL_DIR})
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This should fix the following compiler warning with MSVC
```
 warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
```

## Checklist
- [x] Signed all commits for DCO
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
