### PR TITLE
ign -> gz Namespace Migration : gz-tools

### DIFF
--- a/src/backward.cc
+++ b/src/backward.cc
@@ -1,6 +1,6 @@
 #include "backward.hpp"
 
-namespace ignition {
+namespace gz {
 namespace tools {
 
   backward::SignalHandling sh;


### PR DESCRIPTION
See https://github.com/gazebo-tooling/release-tools/issues/711

Only one change made here, nothing that affects downstream libaries, so no need to ticktock the config.hh.in (it doesn't even exist anyway), and probably no need to update `Migration.md`