### PR TITLE
Source bash completion files for all other gz libraries

### DIFF
--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -14,5 +14,6 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/ign${PROJECT_MAJOR_VERSION}.bash_completion.sh" @ONLY)
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/ign${PROJECT_MAJOR_VERSION}.bash_completion.sh
+  RENAME ign
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${PROJECT_MAJOR_VERSION}.completion.d)
+    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/bash-completion/completions)

--- a/etc/ign.bash_completion.sh
+++ b/etc/ign.bash_completion.sh
@@ -67,4 +67,7 @@ function _ign
 
   COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
 }
+
+source @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATAROOTDIR@/gz/gz@PROJECT_MAJOR_VERSION@.completion
+
 complete -F "_ign" "ign"


### PR DESCRIPTION
# 🎉 New feature

Toward #1
Replaces https://github.com/gazebosim/gz-tools/pull/103 (Creating a new PR with a branch on the upstream repo instead of a fork so I can test with a debbuilder job).

## Summary
Source the `gz*.completion` file from wherever its installed so that the bash completion functions for other gz libraries can be picked up automatically. 

Additionally, this installed the cmake configured `etc/ign.bash_completion.sh` file to `<prefix>/share/bash-completion/completions/ign` instead of relying on the debian/homebrew build infrastructure (see https://github.com/gazebo-release/gz-tools-release/pull/6). This has two advantages (1) makes it easy to use the cmake configured file so we can have cmake variables in `etc/ign.bash_completion.sh` (2) tab completion works the same way when building from source if `<prefix>` is set to `/usr`.

Related:
https://github.com/gazebo-release/gz-tools-release/pull/6

## Test it
To build this with https://github.com/gazebo-release/gz-tools-release/pull/6 on focal, symlink `gz-tools-release/focal/debian` into the the root directory of `gz-tools`, then from the root directory of `gz-tools`, build the deb files using `dpkg-buildpackage -us -uc  -b`. The deb files will be created in the parent directory. You can then copy the debs to a docker container, install it, and test tab completion.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
