### PR TITLE
Improve tab completion behavior when there are no libraries installed

### DIFF
--- a/etc/gz.completion
+++ b/etc/gz.completion
@@ -25,5 +25,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # version numbers, which means functions from newer versions will overwrite
 # those from older versions.
 for f in $SCRIPT_DIR/gz*.completion.d/*.bash_completion.sh ; do
+  [[ -e "$f" ]] || continue
   source $f
 done

--- a/etc/ign.bash_completion.sh
+++ b/etc/ign.bash_completion.sh
@@ -43,7 +43,7 @@ function _ign
 
     # Subcommand is help
     if [[ "$cmd" == "help" ]]; then
-      opts=$(ign --commands)
+      opts=$(ign --commands) || opts=""
 
     # Subcommand is a library name or an option (-*)
     else
@@ -62,7 +62,8 @@ function _ign
 
   # on first word, top-level command (ign)
   else
-    opts="$(ign --commands) help"
+    commands=$(ign --commands) || commands=""
+    opts="${commands} help"
   fi
 
   COMPREPLY=($(compgen -W "${opts}" -- ${cur}))


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
If only `gz-tools` is installed without the other gz libraries, tab completion gives strange results because the output of `ign help` and `ign --commands` is
```
I cannot find any available 'ign' command:
        * Did you install any ignition library?
        * Did you set the IGN_CONFIG_PATH environment variable?
            E.g.: export IGN_CONFIG_PATH=$HOME/local/share/ignition
```
and that's what's used to build up the list of candidates for tab completion. This PR checks if the `ign help` or `ign --commands` ran successfully, otherwise, sets the string to `""` so that it does not participate in tab completion. As a result, only the `help` subcommand is listed as a candidate.

This PR also gets rid of a warning message:
```
bash: /usr/share/gz/gz*.completion.d/*.bash_completion.sh: No such file or directory
```
when manually sourcing the `<prefix>/share/bash-completion/completions/ign` script with no other gz libraries installed.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
