### PR TITLE
Remove ign CLI from version 2

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -9,7 +9,7 @@ release will remove the deprecated code.
 
 * This package now depends on gz-cmake
 * The environment variable `IGN_CONFIG_PATH` is deprecated. Use `GZ_CONFIG_PATH` instead.
-* The `ign` command line executable is deprecated. Use `gz` instead.
+* The `ign` command line executable is removed. Use `gz` instead.
 
 * The project name has been changed to use the `gz-` prefix, you **must** use the `gz` prefix!
   * This also means that any generated code that use the project name (e.g. CMake variables, in-source macros) would have to be migrated.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,17 +64,9 @@ if(WIN32)
   # On Windows also install the gz.bat wrapper script to permit to
   # invoke gz via Command Prompt or Powershell
   install(PROGRAMS gz.bat DESTINATION ${GZ_BIN_INSTALL_DIR})
-
-  # TODO(chapulina) tick-tock ign on Windows if someone actually needs it. It's
-  # complicated to symlink / copy files on Windows.
-else()
-  # TODO(CH3): Deprecated. Tick-tock the ign executable with symlink
-  # This is exceptionally scuffed
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-    ${CMAKE_INSTALL_PREFIX}/${GZ_BIN_INSTALL_DIR}/gz
-    ${PROJECT_BINARY_DIR}/ign)")
-  install(PROGRAMS ${PROJECT_BINARY_DIR}/ign DESTINATION ${GZ_BIN_INSTALL_DIR})
 endif()
+
+# Note: The `ign` CLI isn't installed on purpose so that v2 is co-installable with v1
 
 #===============================================================================
 # BEGIN TEST gz command


### PR DESCRIPTION
## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Initially we intended to provide users with a tick-tock of the CLI, so they could use the `ign` CLI with Garden+ and see warnings. But this means Garden+ wouldn't be co-installable with Citadel and Fortress. Given the option to either:

1. Support side-by-side installation of Citadel/Fortress and Garden
1. Tick-tock the CLI and make a hard change from `ign` to `gz`

We've decided to go with 1. The reasoning is that users should quickly realize that they need to use the new tool. Unlike namespaces and headers, the CLI isn't hardcoded in many places and is mostly invoked by hand, so tick-tock is less important there. On the flip side, side-by-side installation is helpful for migration and mixed systems.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
