### PR TITLE
Support building with gz-cmake3 or gz-cmake4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,17 @@ project(gz-tools2 VERSION 2.0.0)
 #============================================================================
 # Find gz-cmake
 #============================================================================
-find_package(gz-cmake3 REQUIRED)
-set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
+find_package(gz-cmake3 QUIET)
+if (${gz-cmake3_FOUND})
+  set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
+else()
+  find_package(gz-cmake4 QUIET)
+  if (${gz-cmake4_FOUND})
+    set(GZ_CMAKE_VER ${gz-cmake4_VERSION_MAJOR})
+  else()
+    message(FATAL_ERROR "Could not find either gz-cmake3 or gz-cmake4")
+  endif()
+endif()
 
 #============================================================================
 # Configure the project


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1027

## Summary
We are bumping gz-cmake for Ionic to version 4, which would normally mean we would bump gz-tools, but this would prevent us from being able to install Ionic side-by-side with Harmonic and any older Gazebo collection. To remedy that, since we are not relying on any shared libraries from gz-cmake, we can support building with either gz-cmake3 or gz-cmake4.

## Test it
* test with gz-cmake3 by installing it and trying to build this PR
* test with gz-cmake4 by building the `main` branch of gz-cmake and then building this PR.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
