### PR TITLE
Add project soversion information to backward library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,8 +23,11 @@ cmake_policy(PUSH)
 cmake_policy(SET CMP0042 NEW)
 add_library(backward SHARED backward.cc)
 target_link_libraries(backward PUBLIC Backward::Backward)
-set_target_properties(backward PROPERTIES OUTPUT_NAME ${PROJECT_NAME}-backward)
-set_target_properties(backward PROPERTIES CXX_STANDARD 14)
+set_target_properties(backward PROPERTIES
+                      CXX_STANDARD 14
+                      OUTPUT_NAME ${PROJECT_NAME}-backward
+                      SOVERSION ${PROJECT_VERSION_MAJOR}
+                      VERSION ${PROJECT_VERSION_FULL})
 cmake_policy(POP)
 
 if(MSVC)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The library being installed doesn't have a SOVERSION like other libraries created in Gazebo projects, and is flagged as a packaging error by rpmlint.

This will result in a change to the library's filename on Linux, which will now become `libgz-tools2-backward.so.2.0.0`. This is handled correctly by the use of `$<TARGET_FILE_NAME:backward>` for referencing the library in the `gz` executable.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.