### PR TITLE
gz.in: sort list of commands alphabetically

### DIFF
--- a/src/gz.in
+++ b/src/gz.in
@@ -185,7 +185,8 @@ usage = 'The \'gz\' command provides a command line interface to the Gazebo'\
 
 # Used to align the commands and the description.
 padding_width = 15
-commands.each do |cmd, versions|
+commands.keys.sort.each do |cmd|
+  versions = commands[cmd]
   # Calculate the padding to add between the command and the description.
   padding_to_apply = padding_width - cmd.size - 1
   padding = ''


### PR DESCRIPTION
# 🦟 Bug fix

Improves usability of `gz` tool

## Summary

Currently the order of commands listed when running `gz` or `gz help` is a bit random, for example:

~~~
List of available commands:

  help:          Print this help text.
  plugin:        Print information about plugins.
  sdf:           Utilities for SDF files.
  gui:           Launch graphical interfaces.
  fuel:          Manage simulation resources.
  launch:        Run and manage executables and plugins.
  model:         Print information about models.
  sim:           Run and manage the Gazebo Simulator.
  param:         List, get or set parameters.
  gazebo:        Deprecated. Alias for sim.
  topic:         Print information about topics.
  service:       Print information about services.
  log:           Record or playback topics.
  msg:           Print information about messages.
~~~

Note that the `help` command is always listed first, but I've added some alphabetization of the non-`help` commands in this pull request:

~~~
List of available commands:

  help:          Print this help text.
  fuel:          Manage simulation resources.
  gazebo:        Deprecated. Alias for sim.
  gui:           Launch graphical interfaces.
  launch:        Run and manage executables and plugins.
  log:           Record or playback topics.
  model:         Print information about models.
  msg:           Print information about messages.
  param:         List, get or set parameters.
  plugin:        Print information about plugins.
  sdf:           Utilities for SDF files.
  service:       Print information about services.
  sim:           Run and manage the Gazebo Simulator.
  topic:         Print information about topics.
~~~

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
