### PR TITLE
Use relative install path for gz bash completion data

### DIFF
--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_file(
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/gz${PROJECT_MAJOR_VERSION}.completion
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz)
+    ${CMAKE_INSTALL_DATAROOTDIR}/gz)
 
 configure_file(
   "gz.bash_completion.sh"
@@ -16,4 +16,4 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/gz${PROJECT_MAJOR_VERSION}.bash_completion.sh
   RENAME gz
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/bash-completion/completions)
+    ${CMAKE_INSTALL_DATAROOTDIR}/bash-completion/completions)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes an error when building https://github.com/gazebo-release/gz_tools_vendor/ in the ROS buildfarm.

The `DESTINATION` argument of [install](https://cmake.org/cmake/help/v3.10/command/install.html) can take relative paths which is

> interpreted relative to the value of the [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/v3.10/variable/CMAKE_INSTALL_PREFIX.html#variable:CMAKE_INSTALL_PREFIX) variable. The prefix can be relocated at install time using the DESTDIR mechanism explained in the [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/v3.10/variable/CMAKE_INSTALL_PREFIX.html#variable:CMAKE_INSTALL_PREFIX) variable documentation.



## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
