### PR TITLE
Exit with value 1 when the execute call completes

### DIFF
--- a/src/gz.in
+++ b/src/gz.in
@@ -307,3 +307,4 @@ cmd = Cmd.new
 Process.setproctitle("gz #{ARGV.join(' ')}")
 
 cmd.execute(ARGV)
+exit(1)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes [#349](https://github.com/gazebosim/gz-fuel-tools/issues/349)

## Summary
The `gz` tool should return 1 when the command completes successfully. It's assume that subcommands will exit with other values if they fail.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.