### PR TITLE
Fix dll search paths for Ruby on Windows

### DIFF
--- a/src/gz.in
+++ b/src/gz.in
@@ -289,6 +289,13 @@ if ARGV.include?('--versions')
   exit(0)
 end
 
+if defined? RubyInstaller
+  # RubyInstaller does not search for dlls in PATH
+  # https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#-dll-loading
+  ENV['RUBY_DLL_PATH'] = ENV['PATH']
+  RubyInstaller::Runtime.enable_dll_search_paths
+end
+
 # Start Backward before loading plugins
 begin
   SharedLibInterface::Importer.dlload '@backward_library_name@'


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The version of Ruby we use in our CI comes from https://rubyinstaller.org/, which according to their [wiki](
https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#-dll-loading) says that the `PATH` environment variable is ignored when searching for dlls. This has been one of the reasons the `gz` tool doesn't work on Windows in our CI. This patch fixes it by setting `RUBY_DLL_PATH` equal to `PATH`.

Needed by https://github.com/gazebosim/sdformat/pull/1374

Successful build in [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-pr-win&build=923)](https://build.osrfoundation.org/job/sdformat-pr-win/923/)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
