### PR TITLE
Backport: Fix dll search paths for Ruby on Windows (#140)

### DIFF
--- a/src/ign.in
+++ b/src/ign.in
@@ -281,6 +281,13 @@ if ARGV.include?('--versions')
   exit(0)
 end
 
+if defined? RubyInstaller
+  # RubyInstaller does not search for dlls in PATH
+  # https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#-dll-loading
+  ENV['RUBY_DLL_PATH'] = ENV['PATH']
+  RubyInstaller::Runtime.enable_dll_search_paths
+end
+
 # Start Backward before loading plugins
 begin
   SharedLibInterface::Importer.dlload '@backward_library_name@'


### PR DESCRIPTION
# Backport

Backporting #140 

**Note to maintainers**: Remember to **Rebase**
