### PR TITLE
Add colcon.pkg with gz-cmake4 dependency

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["gz-cmake4"],
+}

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -4,5 +4,7 @@
 #   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
 
 {
+  # explicitly add gz-cmake4 as a dependency since it is not included in the package.xml
+  # see https://github.com/gazebosim/gz-tools/pull/142 for discussion of alternatives
   "dependencies": ["gz-cmake4"],
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes `colcon` build ordering since #136 was merged

## Summary

Since https://github.com/gazebosim/gz-tools/pull/128, `gz-tools2` supports building with either `gz-cmake3` or `gz-cmake4`, and `colcon` was correctly identifying the dependency relationship due to the cmake `find_package` calls. A `package.xml` was added in #136 with a `build_depend` only on `gz-cmake3`, which now breaks the build-from-source order for Ionic workspaces that include `gz-tools2`:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-main-win&build=43)](https://build.osrfoundation.org/view/gz-ionic/job/sdformat-main-win/43/) https://build.osrfoundation.org/view/gz-ionic/job/sdformat-main-win/43/

~~~
Starting >>> gz-cmake4
Starting >>> gz-tools2
--- output: gz-tools2
-- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.20348.
-- The C compiler identification is MSVC 19.29.30148.0
-- The CXX compiler identification is MSVC 19.29.30148.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at CMakeLists.txt:19 (message):
  Could not find either gz-cmake3 or gz-cmake4


-- Configuring incomplete, errors occurred!
~~~

This pull request adds a `colcon.pkg` file with an explicit dependency on `gz-cmake4` to fix the build order

* test with this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-main-win&build=45)](https://build.osrfoundation.org/view/gz-ionic/job/sdformat-main-win/45/) https://build.osrfoundation.org/view/gz-ionic/job/sdformat-main-win/45/

### Alternatives considered

* Use the `colcon.pkg` to force the build type back to `cmake`: https://github.com/gazebosim/gz-tools/commit/f18e5846887f2e290abcbc9f5ae6e0e8fa2aed42. This also fixes the build ([![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-main-win&build=44)](https://build.osrfoundation.org/view/gz-ionic/job/sdformat-main-win/44/)), but it has more side-effects that just adding `gz-cmake4` as a dependency.
* Add `<member_of_group>gz-cmake</member_of_group>` to the `package.xml` file in `gz-cmake3` and `gz-cmake4` and a `<group_depend>gz-cmake</group_depend>` tag in downstream package.xml files (thanks to @cottsay for the suggestion). This is more elegant but requires more coordination between packages, while this `colcon.pkg` change can fix CI now.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
