### PR TITLE
Add GitHub CI for 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,12 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@noble

--- a/src/gz.in
+++ b/src/gz.in
@@ -56,12 +56,12 @@ conf_dirs = conf_dirs.split('@ENV_PATH_DELIMITER@')
 conf_dirs.append(ENV['IGN_CONFIG_PATH']) if ENV.key?('IGN_CONFIG_PATH')
 
 conf_dirs.each do |conf_directory|
-  next if Dir.glob(conf_directory + '/*.yaml').empty?
+  next if Dir.glob("#{conf_directory}/*.yaml").empty?
 
   yaml_found = true
 
   # Iterate over the list of configuration files.
-  Dir.glob(conf_directory + '/*.yaml') do |conf_file|
+  Dir.glob("#{conf_directory}/*.yaml") do |conf_file|
     next if conf_file == [',', '..'].any?
 
     # Read the configuration file.
@@ -194,7 +194,7 @@ commands.keys.sort.each do |cmd|
     padding += ' '
   end
 
-  usage += '  ' + cmd + ':' + padding + versions.first[1]['description'] + "\n"
+  usage += "  #{cmd}:#{padding}#{versions.first[1]['description']}\n"
 end
 
 usage += "\nOptions:\n\n"\


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1222

## Summary

Enables 24.04 CI for `gz-tools2` and fixes some rubocop complaints.

## Test it

Verify that CI passes.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
