### PR TITLE
Use rotary unversioned packages for CI

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,2 +1,2 @@
-libgz-cmake-dev
+libgz-rotary-cmake-dev
 rubocop

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,2 +1,2 @@
-libgz-cmake5-dev
+libgz-cmake-dev
 rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,5 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
+        with:
+          gzdev-project-name: rotary


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1446