### PR TITLE
Improve accuracy of colcon-test-result

### DIFF
--- a/cmake/run_test.cmake
+++ b/cmake/run_test.cmake
@@ -8,7 +8,7 @@ execute_process(COMMAND ruby ${GZ_SCRIPT}
 # previous results.
 execute_process(COMMAND
   ${CMAKE_COMMAND} -E copy
-  "${TEST_NAME}_fail.xml"
+  "${TEST_NAME}_fail.xml.configured"
   "../test_results/${TEST_NAME}.xml"
 )
 
@@ -17,7 +17,7 @@ if (${TEST_OUTPUT} MATCHES "Test executed" AND NOT
     (${TEST_ERROR} MATCHES "Library error")))
   execute_process(COMMAND
     ${CMAKE_COMMAND} -E copy
-    "${TEST_NAME}_pass.xml"
+    "${TEST_NAME}_pass.xml.configured"
     "../test_results/${TEST_NAME}.xml"
   )
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,12 +101,12 @@ if(BUILD_TESTING)
 
   configure_file(
     "${PROJECT_SOURCE_DIR}/tools/junit_pass.xml.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}_pass.xml"
+    "${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}_pass.xml.configured"
     @ONLY)
 
   configure_file(
     "${PROJECT_SOURCE_DIR}/tools/junit_fail.xml.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}_fail.xml"
+    "${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}_fail.xml.configured"
     @ONLY)
 
   # This simply executes gz. The output will be tested in the check_* test


### PR DESCRIPTION
# 🦟 Bug fix

Helps with https://github.com/gazebosim/sdformat/pull/1648

## Summary

While experimenting with `action-ros-ci` in https://github.com/gazebosim/sdformat/pull/1648, I noticed that `colcon test-result` incorrectly identifies a failed test in a `gz-tools` build folder even when tests haven't been run due to the `.xml` suffix of the intermediate `${TEST_NAME}_fail.xml` file (also known as `UNIT_gz_TEST_fail.xml`).

Adding a suffix to the intermediate junit xml files prevents `colcon test-result` from reading them as real test results.

To test:

1. create a colcon workspace containing `gz-tools`
2. `colcon build`
3. `colcon test-result` should not show a failure
4. `colcon test && colcon test-result` still should not show the spurious failure

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
