### PR TITLE
fix: Add special handling for backward library path on windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,10 +45,16 @@ install (TARGETS backward
 # Compute a path relative to the bin dir so the gz script can find the backward
 # library without relying on LD_LIBRARY_PATH/DYLD_LIBRARY_PATH and without
 # using absolute paths (which break CMAKE_STAGING_PREFIX and relocatability).
-file(RELATIVE_PATH _backward_relpath
-  ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}
-  ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
-set(backward_library_name ${_backward_relpath}/$<TARGET_FILE_NAME:backward>)
+if (NOT MSVC)
+  file(RELATIVE_PATH _backward_relpath
+    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}
+    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+  set(backward_library_name ${_backward_relpath}/$<TARGET_FILE_NAME:backward>)
+else()
+  # On Windows, dll files are installed in `bin`, right next to the `gz`
+  # executable, so there is no need to compute a relative path.
+  set(backward_library_name $<TARGET_FILE_NAME:backward>)
+endif()
 
 # Two steps to create `gz`, First using `configure_file`, to interpolate cmake variables. Then
 # use `file(GENERATE ...)` to use generator expressions


### PR DESCRIPTION
# 🦟 Bug fix

Relates to test failure in sdformat (see https://github.com/gazebosim/gz-tools/pull/174#issuecomment-4516180479)

## Summary
On windows, dll files are installed in `bin` as opposed to `lib` on Linux and macOS.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.