### PR TITLE
ci: test on Ubuntu Resolute (26.04)

### DIFF
--- a/.github/ci/packages-jammy.apt
+++ b/.github/ci/packages-jammy.apt
@@ -1,0 +1,1 @@
+libgz-cmake3-dev

--- a/.github/ci/packages-noble.apt
+++ b/.github/ci/packages-noble.apt
@@ -1,0 +1,1 @@
+libgz-cmake5-dev

--- a/.github/ci/packages-resolute.apt
+++ b/.github/ci/packages-resolute.apt
@@ -1,0 +1,1 @@
+libgz-cmake5-dev

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,2 +1,1 @@
-libgz-cmake3-dev
 rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Ubuntu Jammy CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
@@ -23,7 +23,16 @@ jobs:
     name: Ubuntu Noble CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
+  resolute-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Resolute CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@resolute


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1503

## Summary

Enable Ubuntu CI on 26.04 with the `resolute` branch of action-gz-ci. Also update actions/checkout to v7


## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Test it

Verify that CI passes

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
